### PR TITLE
better links parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "tweet-baker": "^1.0.0",
     "tweets-stats": "^1.0.0",
     "twitter-profile-media": "^0.1.1",
+    "twitter-regexps": "^1.0.8",
     "twitter-tokens": "^1.0.1",
     "typographic-numbers": "^0.2.1"
   },

--- a/posts.js
+++ b/posts.js
@@ -48,7 +48,9 @@ const post = (author, post = true) => {
             groups[domain] = [];
           }
 
-          groups[domain].push(url);
+          if (-1 === groups[domain].indexOf(url)) {
+            groups[domain].push(url);
+          }
         }
       }
 


### PR DESCRIPTION
Парсинг ссылок той же регуляркой, что твиттер парсит их в свои entities. Заодно убрал дупликаты.
Ссылок в постах станет больше. Обновлять посты не стал - там что-то с датами не то, наверное берется временная зона того, кто генерит.
