### PR TITLE
Скачивание изображений на Тревисе

### DIFF
--- a/helpers/load.js
+++ b/helpers/load.js
@@ -1,15 +1,17 @@
+import http from 'http';
+import https from 'https';
+import { parse as parseUrl } from 'url';
 import { createWriteStream } from 'fs-extra';
-import got from 'got';
 import mime from 'mime';
 import magic from 'stream-mmmagic';
 
 export default function load(imageUrl, targetName, cb) {
-  got.stream(imageUrl, { encoding: null })
-  .on('response', response => {
-    if (response.statusCode >= 400) {
-      return cb(new Error(`✖ Error ${response.statusCode} for ${targetName}`));
+  const proto = parseUrl(imageUrl).protocol === 'https:' ? https : http;
+  proto.get(imageUrl, res => {
+    if (res.statusCode > 399) {
+      return cb(new Error(`✖ Error ${res.statusCode} for ${targetName}`));
     }
-    magic(response, (err, { type }, output) => {
+    magic(res, (err, { type }, output) => {
       // `mime` uses `jpeg` as extension for `image/jpeg`
       const targetExt = (type === 'image/jpeg') ? 'jpg' : mime.extension(type);
       const targetFilename = `${targetName}.${targetExt}`;


### PR DESCRIPTION
Для загрузки используются встроенные `http` и `https`, потому что `got` скачивал битые изображения.
