### PR TITLE
add detailed info on followers gained\lost per author

### DIFF
--- a/dump/index.js
+++ b/dump/index.js
@@ -4,6 +4,7 @@ import getAuthorArea from '../helpers/get-author-area';
 
 const saturate = author => merge(author, {
   info: getAuthorArea(author.username, 'info') || {},
+  followers: getAuthorArea(author.username, 'followers').followers || [],
   tweets: getAuthorArea(author.username, 'tweets').tweets || [],
   media: getAuthorArea(author.username, 'media') || {},
   mentions: getAuthorArea(author.username, 'mentions').mentions || [],

--- a/layouts/stats.jade
+++ b/layouts/stats.jade
@@ -58,15 +58,18 @@ block content
                       .tweet-graph__bar.tweet-graph__bar_retweets(style='width: #{author.retweets.percent}%;')
                       .tweet-graph__bar.tweet-graph__bar_replies( style='width: #{author.replies.percent}%;' )
 
-                td.host-stats__col(data-title='Читатели' data-sort=author.gainedFollowers class={
-                  'text-muted': author.gainedFollowers === 0,
-                  'text-success': author.gainedFollowers > 0,
-                  'text-danger': author.gainedFollowers < 0
-                })
+                td.host-stats__col(data-title='Читатели' data-sort=author.followersDiff )
                   span.cell(class={ 'cell--best': author.maxGainedfollowers }): span.cell__content
-                    if author.gainedFollowers !== 0
-                      = author.gainedFollowers > 0 ? '+' : '−'
-                    = Math.abs(author.gainedFollowers)
+                    span(class={
+                      'text-muted': author.followersDiff === 0,
+                      'text-success': author.followersDiff > 0,
+                      'text-danger': author.followersDiff < 0
+                    })
+                      if author.followersDiff !== 0
+                        = author.followersDiff > 0 ? '+' : '−'
+                      = Math.abs(author.followersDiff)
+                    span
+                      = author.followersValid ? '(+' + author.followersGained + '/' + '-' + author.followersLost + ')' : ''
                 td.host-stats__col(data-title='Твиты' data-sort=author.tweets)
                   span.cell(class={ 'cell--best': author.maxTweets } ): span.cell__content
                     = author.tweets

--- a/stats.js
+++ b/stats.js
@@ -1,21 +1,34 @@
 import stats from 'tweets-stats';
 import maxValues from 'max-values';
 import { merge } from 'ramda';
+import { difference } from 'underscore';
+
+const getFollowerStats = (prevAuthor, curAuthor) => ({
+  followersGained: difference(curAuthor, prevAuthor).length,
+  followersLost: difference(prevAuthor, curAuthor).length
+});
 
 const getStatsPerAuthor = authors =>
   authors
-    .map(author => merge(author, { followers: author.info.followers_count }))
-    .map((author, i, arr) => merge(author, {
-      gainedFollowers: arr[i + 1]
-        ? (author.followers - arr[i + 1].followers)
-        : author.followers,
+    .map(author => merge(author, {
+      followersCount: author.info.followers_count,
+      followers: author.followers.map(follower => follower.id)
+    }))
+    .map((author, i, arr) => merge(author,
+      arr[i + 1]
+        ? merge({followersDiff: author.followersCount - arr[i + 1].followersCount},
+        getFollowerStats(arr[i + 1].followers, author.followers))
+        : {followersGained: author.followersCount, followersLost: 0, followersDiff: author.followersCount}
+    ))
+    .map(author => merge(author, {
+      followersValid: Math.abs(author.followersGained - author.followersLost) === Math.abs(author.followersDiff)
     }))
     .map(author => merge(author, stats(author.tweets)));
 
 export default function getStats(authors) {
   if (!authors || authors.length === 0) return;
   return maxValues(getStatsPerAuthor(authors), [
-    'tweets', 'gainedFollowers',
+    'tweets', 'followersDiff', 'followersGained', 'followersLost', 'followersValid',
     'own.total', 'replies.total', 'retweets.total',
     'favorited.total', 'favorited.average',
     'retweeted.total', 'retweeted.average',


### PR DESCRIPTION
the data is validated as it is inconsistent: no followers dumps until some point
![followers_stats](https://cloud.githubusercontent.com/assets/4169710/12784334/63a2f180-caa8-11e5-9153-c0c513791315.png)
